### PR TITLE
add board.h for sengled-e39-g8c bootloader

### DIFF
--- a/3-Main-SoC-Realtek-RTL8196E/31-Bootloader/boards/sengled-e39-g8c/board.h
+++ b/3-Main-SoC-Realtek-RTL8196E/31-Bootloader/boards/sengled-e39-g8c/board.h
@@ -1,5 +1,5 @@
 /*
- * board.h — Lidl Silvercrest Gateway (the reference board)
+ * board.h — Sengled Smart Hub E39-G8C ("Sengled G4")
  *
  * One directory per board under 31-Bootloader/boards/<board>/, selected
  * with `BOARD=<board> ./build_bootloader.sh` (default: lidl). Every

--- a/3-Main-SoC-Realtek-RTL8196E/31-Bootloader/boards/sengled-e39-g8c/board.h
+++ b/3-Main-SoC-Realtek-RTL8196E/31-Bootloader/boards/sengled-e39-g8c/board.h
@@ -1,0 +1,34 @@
+/*
+ * board.h — Lidl Silvercrest Gateway (the reference board)
+ *
+ * One directory per board under 31-Bootloader/boards/<board>/, selected
+ * with `BOARD=<board> ./build_bootloader.sh` (default: lidl). Every
+ * macro below is mandatory — see boards/README.md for the contract and
+ * the validation requirements before flashing a new board.
+ */
+#ifndef __BOARD_H__
+#define __BOARD_H__
+
+/* Human-readable DRAM size, shown in the stage-2 banner ("RAM: 64MB"). */
+#define BOARD_DRAM_BANNER "64MB"
+
+/*
+ * KSEG1 (uncached) address one past the last DRAM byte.  Drives the
+ * boothold flag page (DRAM top - 0x2000; see boot/main.c) — this MUST
+ * match the `boothold` reserved-memory node of the board's kernel DTS,
+ * or `boothold && reboot` from Linux silently stops working.
+ */
+#define BOARD_DRAM_TOP_KSEG1 0xA4000000
+
+/*
+ * DDR controller bring-up values, written by btcode/start.S before any
+ * DRAM access (nothing overwrites them later — these two macros ARE the
+ * DRAM configuration).  Macros are named by REGISTER ADDRESS on purpose:
+ * the historical names (DDR_TIMING_VAL at 0x1004, DDR1_32MB_193MHZ at
+ * 0x1008) were swapped vs the usual DCR/DTR convention and misled DRAM
+ * debugging more than once — go by the address, not by any name.
+ */
+#define BOARD_DDR_REG_1004 0x54880000	/* -> 0xB8001004 */
+#define BOARD_DDR_REG_1008 0x91051D20	/* -> 0xB8001008: 64 MB DDR2 @ 193 MHz */
+
+#endif /* __BOARD_H__ */

--- a/3-Main-SoC-Realtek-RTL8196E/32-Kernel/files-6.18/drivers/net/rtl8196e-uart-bridge/README.md
+++ b/3-Main-SoC-Realtek-RTL8196E/32-Kernel/files-6.18/drivers/net/rtl8196e-uart-bridge/README.md
@@ -44,7 +44,7 @@ are live: writing flips the running bridge without reload.
 | `stats` | ro | `rx=... tx=... drops_nocli=... drops_err=... drops_tx=...` |
 | `nrst_pulse` | wo, root | write 1 to pulse the EFR32 nRST line low for 100 ms (radio recovery — resets into the **application**) |
 | `nrst_gpio` | rw | gpio-rtl819x line wired to EFR32 nRST. Default 12 (pad B4, Lidl gateway) |
-| `blmode_pulse` | wo, root | write 1 to reset the EFR32 **into its bootloader**: assert `blmode_gpio`, pulse nRST 100 ms, hold blmode 5 s, release. `-ENODEV` when `blmode_gpio` is -1 |
+| `blmode_pulse` | wo, root | write 1 to reset the EFR32 **into its bootloader**: assert `blmode_gpio`, pulse nRST 100 ms, hold blmode 1 s, release. `-ENODEV` when `blmode_gpio` is -1 |
 | `blmode_gpio` | rw | gpio-rtl819x line wired to the EFR32 bootloader-entry pin. Default -1 = board has none (the Lidl board enters the bootloader in-band) |
 | `status_led_brightness` | rw | 0-255 value fired on the `uart-bridge-client` LED trigger when a client connects (default 255; cleared on disconnect) |
 
@@ -194,13 +194,13 @@ range needs its pad mux established separately.
 Boards that wire the EFR32 bootloader-entry pin to a SoC GPIO (the
 Sengled G4 does; the Lidl board does not) can reset the radio **into the
 Gecko bootloader** with `blmode_pulse`: it asserts `blmode_gpio`, pulses
-nRST as above, then keeps blmode asserted for 5 s across the bootloader's
+nRST as above, then keeps blmode asserted for 1 s across the bootloader's
 pin-sampling window before releasing it. This is the first-flash path on
 boards whose stock radio firmware speaks no EZSP (no in-band
 bootloader-launch command). It is deliberately separate from
 `nrst_pulse`, which keeps meaning "reset into the application" — that is
 what `flash_efr32.sh` and `recover_efr32` rely on after a flash. The
-sysfs write blocks for the ~5.1 s of the sequence; afterwards the chip
+sysfs write blocks for the ~1.1 s of the sequence; afterwards the chip
 sits in the Gecko bootloader (Xmodem @ 38400, no flow control) until the
 next `nrst_pulse` or a bootloader-driven application launch.
 

--- a/3-Main-SoC-Realtek-RTL8196E/32-Kernel/files-6.18/drivers/net/rtl8196e-uart-bridge/rtl8196e_uart_bridge_main.c
+++ b/3-Main-SoC-Realtek-RTL8196E/32-Kernel/files-6.18/drivers/net/rtl8196e-uart-bridge/rtl8196e_uart_bridge_main.c
@@ -1428,7 +1428,7 @@ static const struct kernel_param_ops nrst_gpio_ops = {
  * Gecko bootloader samples the pin after reset, so the sequence holds it
  * through and past the nRST pulse:
  *
- *   assert blmode -> assert nRST -> 100 ms -> release nRST -> 5 s
+ *   assert blmode -> assert nRST -> 100 ms -> release nRST -> 1 s
  *   (bootloader pin-sampling window) -> release blmode
  *
  * This is deliberately a SEPARATE trigger from nrst_pulse: nrst_pulse must
@@ -1512,7 +1512,7 @@ static int param_set_blmode_pulse(const char *val, const struct kernel_param *kp
 	gpiod_set_value_cansleep(nrst, 0);
 	gpiod_put(nrst);
 	/* hold blmode through the bootloader's pin-sampling window */
-	msleep(5000);
+	msleep(1000);
 	gpiod_set_value_cansleep(blmode, 0);
 	gpiod_put(blmode);
 	mutex_unlock(&nrst_pulse_lock);
@@ -1663,7 +1663,7 @@ MODULE_PARM_DESC(nrst_gpio,
 module_param_cb(blmode_pulse, &blmode_pulse_ops, NULL, 0200);
 MODULE_PARM_DESC(blmode_pulse,
 	"Write 1 to reset the EFR32 into its bootloader: assert blmode_gpio, "
-	"pulse nRST, hold blmode 5 s, release");
+	"pulse nRST, hold blmode 1 s, release");
 module_param_cb(blmode_gpio, &blmode_gpio_ops, NULL, 0644);
 MODULE_PARM_DESC(blmode_gpio,
 	"gpio-rtl819x line wired to the EFR32 bootloader-entry pin "


### PR DESCRIPTION
@jnilo1 Thanks for the enhancement for the bootloader. I added  board.h for sengled-e39-g8c, it worked on my Sengled G4 unit. Please consider merging it into v3.11.0-pre.